### PR TITLE
Sort also top level directories with respect to order.

### DIFF
--- a/syntax/SplFileArray.php
+++ b/syntax/SplFileArray.php
@@ -63,6 +63,14 @@ class SplFileArray
 		}
 
 		uasort($array, array($this, 'sortDir'));
+		
+		// sort also top level directories
+		if ($this->fileorder === 'asc') {
+			ksort($array);
+		}
+		elseif ($this->fileorder === 'desc') {
+			krsort($array);
+		}
 
 		return $array;
 	}


### PR DESCRIPTION
When you list several directories and they are empty, then their order is random thanks to unstable sorting and may be undefined order of load from FS by FileSystemIterator. (For unstable sort see lines 87 and 90 in SplFileArray.php)

So after sorting the inner objects by comparing getFilename() it will be neccessary to sort also top level by keys which contains dir names.

Feature idea:
To support distinct order for dirs and files. I actually doesn't need it so I only mentioned it.
